### PR TITLE
Fix deprecated usage of sortlist

### DIFF
--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -7,7 +7,7 @@ nameserver <%= ns %>
 <% if @search -%>
 search <%= @search %>
 <% end -%>
-<% if !sortlist.empty? -%>
+<% if !@sortlist.empty? -%>
 sortlist <%= @sortlist.join(' ') %>
 <% end -%>
 <% if @options -%>


### PR DESCRIPTION
Fixes warnings in puppet apply output, these warnings often repeat making it difficult to discern the relevant output.

```
Warning: Variable access via 'sortlist' is deprecated. 
Use '@sortlist' instead. template[.../modules/resolv_conf/templates/resolv.conf.erb]:10
```
